### PR TITLE
Create webapp dir if run alone

### DIFF
--- a/roles/vascan_editor/defaults/main.yml
+++ b/roles/vascan_editor/defaults/main.yml
@@ -3,6 +3,7 @@ tomcat_user:        tomcat8
 tomcat_webapps:     '{{ vascan_dir_root }}/webapps'
 
 vascan_editor_apps_dir:
+  tomcat_web_apps: '{{ tomcat_webapps }}'
   generated_content:  '{{ vascan_dir.downloadable_content }}'
   vascan_sitemap  :   '{{ vascan_dir_public }}/sitemap/vascan/'
   mysql_backup_dir:  '{{ vascan_dir_root }}/vascan-editor-data/mysqldump/'


### PR DESCRIPTION
If the vascan-editor role is run alone, the webapp folder shall be created by the role