### PR TITLE
Allow app_vascan_editor to build from source

### DIFF
--- a/roles/app_vascan_editor/defaults/main.yml
+++ b/roles/app_vascan_editor/defaults/main.yml
@@ -16,7 +16,7 @@ dir_webapps : '{{ dir_root }}/webapps'
 ## backup directory
 backup_root : '/Backups'
 ## tmp deploy
-tmp_checkout_dir: '/tmp/vascan/checkout'
+tmp_checkout_dir: '/tmp/vascan-editor/checkout'
 
 # Tomcat
 tomcat_user     : tomcat8
@@ -75,8 +75,19 @@ vascan_editor_db_dest    : '{{ tmp_checkout_dir }}'
 vascan_editor_db_zip     : '{{ tmp_checkout_dir }}/mysqldump_vascan_editor.gz'
 
 # War File
-vascan_editor_war_file  : vascan-editor.war
-vascan_editor_war_url   : 'https://www.dropbox.com/yourfile_vascan-editor.war?dl=1'
+# vascan_editor_war_file  : vascan-editor.war
+# vascan_editor_war_url   : 'https://www.dropbox.com/yourfile_vascan-editor.war?dl=1'
+
+# Source Code
+vascan_editor_source_repo: https://github.com/JeGoi/vascan-editor
+vascan_editor_source_folder_name: code
+vascan_editor_source_root_dir: '{{ tmp_checkout_dir }}'
+vascan_editor_source_dir: '{{ vascan_editor_source_root_dir }}/{{ vascan_editor_source_folder_name }}'
+
+# local path (on the machine that will run this script)
+vascan_editor_source_checkout_dir_local: '/tmp/vascan-editor-source/{{ vascan_editor_source_folder_name }}'
+vascan_editor_source_checkout_dir_compressed: '{{ vascan_editor_source_checkout_dir_local }}-archive.gz'
+vascan_editor_source_version: master
 
 # NFS Directories
 #vascan_editor_nfs         : '{{ nfs_root }}/{{ vascan_editor_c_name }}'
@@ -85,13 +96,15 @@ vascan_editor_war_url   : 'https://www.dropbox.com/yourfile_vascan-editor.war?dl
 
 # Directories
 vascan_editor_dir                       : '{{ dir_root }}'
+# TO CHECK -> public folder is a shared folder with vascan so that the editor can put the complete DarwinCore archive there and it will be accessible via vascan (public url to download it)
 vascan_editor_dir_public                : '{{ vascan_editor_dir }}/public'
-vascan_editor_dir_downloads             : '{{ vascan_portal_dir_public }}/downloads'
+vascan_editor_dir_downloads             : '{{ vascan_editor_dir_public }}/downloads'
 vascan_editor_dir_downloadable_content  : '{{ vascan_editor_dir_downloads }}/vascan'
 vascan_editor_dir_generated_content     : '{{ vascan_editor_dir_downloadable_content }}'
 vascan_editor_dir_vascan_sitemap        : '{{ vascan_editor_dir_public }}/sitemap/vascan/'
 # To be linked with nfs
 vascan_editor_dir_vascan_editor_data: '{{ vascan_editor_dir }}/vascan-editor-data'
+vascan_editor_dir_vascan_editor_log: '{{ vascan_editor_dir_vascan_editor_data }}/vascan-editor.log'
 vascan_editor_dir_mysqldump         : '{{ vascan_editor_dir_vascan_editor_data }}/mysqldump/'
 vascan_editor_dir_dwca              : '{{ vascan_editor_dir_vascan_editor_data }}/dwca/'
 vascan_editor_dir_change_log        : '{{ vascan_editor_dir_vascan_editor_data }}/changelog/'
@@ -128,14 +141,27 @@ vascan_editor_backup_dir  : '{{ backup_root }}/{{ vascan_editor_c_name }}'
 # config file
 vascan_editor_config_d: '{{ vascan_editor_dir }}/webapps/vascan-editor/WEB-INF/classes/installation_cfg.properties'
 vascan_editor_config_s: 'installation_cfg.properties.j2'
-vascan_editor_RootURL : 'http://data.canadensys.net/vascan-editor/'
+vascan_editor_portal_url : 'http://data.canadensys.net/vascan/' #url of the vascan portal (not the editor)
 vascan_editor_mysql_cmd         : mysql
 vascan_editor_mysql_dump_cmd    : mysqldump
 vascan_editor_elasticsearch_host: localhost
-vascan_editor_last_publication_date: '{{ vascan_portal_last_publication_date }}'
-vascan_editor_GeneratedImagesDir  : '{{ vascan_portal_dir_generated_images }}'
+vascan_editor_last_publication_date: '/tmp'
+
+# TO CHECK -> vascan_editor_GeneratedImagesDir should be the exact same folder as vascan_portal_dir_generated_content from app_vascan_portal role
+vascan_editor_GeneratedImagesDir  : '{{ vascan_editor_dir_generated_content }}'
 vascan_editor_MetaXMLDir          : '{{ vascan_editor_dir }}/webapps/vascan-editor/WEB-INF/classes/'
 vascan_editor_email: your_email@your.email.com
 vascan_editor_smtp_host: localhost
-vascan_editor_data: '{{ vascan_dir_root }}/vascan-editor-data'
-vascan_editor_public: '{{ vascan_dir_root }}//public/'
+
+#should come from vascan role (a generic role since they shall always match)
+elastic_search_rivers:
+  taxon:
+    sql: >
+       SELECT l1.taxonid as _id, l1.calname as taxonname, l1.calname as sortname, l1.calnamehtml as namehtml,
+       l1.calnamehtmlauthor as namehtmlauthor, l1.status, taxonomy.parentid, l2.calnamehtml AS parentnamehtml,
+       l1.rank as rankname FROM lookup l1 LEFT OUTER JOIN taxonomy on childid = taxonid LEFT OUTER JOIN lookup as l2
+       ON l2.taxonid = taxonomy.parentid
+    name: vascan_taxon_jdbc_river
+  vernacular:
+    sql: SELECT v.id AS _id, v.taxonid, name as vernacularname, name as sortname, s.status, language, calnamehtml AS taxonnamehtml FROM vernacularname v INNER JOIN status s on statusid = s.id INNER JOIN lookup ON lookup.taxonid=v.taxonid
+    name: vascan_vernacular_jdbc_river

--- a/roles/app_vascan_editor/tasks/main.yml
+++ b/roles/app_vascan_editor/tasks/main.yml
@@ -11,6 +11,7 @@
   tags:
     - editor
     - editor-directories
+    - editor2
 
 # Setup MySQL Database
 - name: Create databases in MySql
@@ -184,26 +185,110 @@
     - editor-directories
 
 # Setup application file
-- name: Move Vascan Editor WAR to Tomcat
-  become: true
-  copy:
-    src     : '{{ vascan_editor_war_file }}'
-    dest    : '{{ tomcat_webapps }}'
-  ignore_errors: yes
-  register: stat_bk_vascan_editor_war
-  notify: restart tomcat
-  tags:
-    - editor
-    - editor-war
+#- name: Move Vascan Editor WAR to Tomcat
+#  become: true
+#  copy:
+#    src     : '{{ vascan_editor_war_file }}'
+#    dest    : '{{ tomcat_webapps }}'
+#  ignore_errors: yes
+#  register: stat_bk_vascan_editor_war
+#  notify: restart tomcat
+#  tags:
+#    - editor
+#    - editor-war
 
-- name: Download war file from Dropbox
-  become: true
-  shell: "wget -O {{ tomcat_webapps }}/vascan-editor.war {{vascan_editor_war_url }}"
-  notify: restart tomcat
-  when : vascan_editor_war_url is defined and stat_bk_vascan_editor_war.failed
+- name: Clone Vascan-Editor from GitHub locally (since it's a private repo)
+  become: false
+  local_action: 
+    module: git
+    repo: '{{ vascan_editor_source_repo }}'
+    dest: '{{ vascan_editor_source_checkout_dir_local }}'
+    version: '{{ vascan_editor_source_version }}'
   tags:
-    - editor
-    - editor-war
+    - editor2
+
+- name: Compress Vascan-Editor
+  become: false
+  local_action: 
+    module: archive
+    path: '{{ vascan_editor_source_checkout_dir_local }}'
+    dest: '{{ vascan_editor_source_checkout_dir_compressed }}'
+    #remove: yes
+  tags:
+    - editor2
+
+- name: Uncompress Vascan-Editor on remote
+  unarchive:
+    src: '{{ vascan_editor_source_checkout_dir_compressed }}'
+    dest: '{{ vascan_editor_source_root_dir }}'
+  tags:
+    - editor2
+
+- name: Create Vascan-Editor properties file 
+  template:
+    src   : '{{ vascan_editor_config_s }}'
+    dest  : '{{ vascan_editor_source_dir }}/config/editor_installation_cfg.properties'
+  tags:
+    - editor2
+
+- name: Create Vascan-Editor log4j config file 
+  template:
+    src   : 'log4j.properties.j2'
+    dest  : '{{ vascan_editor_source_dir }}/log4j.properties'
+  tags:
+    - editor2
+
+- name: Create Vascan-Editor river files
+  become: true
+  template:
+    src   : elastic_search_river.json.j2
+    dest  : '{{ vascan_editor_source_dir }}/config/create_vascan_{{ item.key }}_river.txt'
+  with_dict: '{{ elastic_search_rivers }}'
+  tags:
+    - editor2
+
+# Vascan-Editor is using Ant as build tool
+- name: Install Apache Ant
+  become: true
+  apt:
+    pkg: maven
+    state: present
+    update_cache    : yes
+  tags:
+    - editor2
+
+- name: Build Vascan-Editor
+  command: ant war
+  args:
+    chdir: '{{ vascan_editor_source_dir }}'
+  tags:
+    - editor2
+
+- name: Copy Vascan-Editor war to tomcat webapps folder
+  copy:
+    src: '{{ vascan_editor_source_dir }}/deploy/vascan-editor.war'
+    dest: '{{ tomcat_webapps }}/vascan-editor.war'
+    remote_src: true
+  notify: restart tomcat
+  tags:
+   - editor2
+
+# - name: Create Vascan config
+#   template:
+#      src: vascan-config.properties.j2
+#      dest: '{{ source_dict.vascan.checkout_dir }}/config/production/vascan-config.properties'
+#   tags:
+#     - portal
+#     - portal-webapp
+
+# - name: Download war file from Dropbox
+#   become: true
+#   shell: "wget -O {{ tomcat_webapps }}/vascan-editor.war {{vascan_editor_war_url }}"
+#   notify: restart tomcat
+#   when : vascan_editor_war_url is defined and stat_bk_vascan_editor_war.failed
+#   tags:
+#     - editor
+#     - editor-war
 
 - name: Restart tomcat
   become: true

--- a/roles/app_vascan_editor/templates/elastic_search_river.json.j2
+++ b/roles/app_vascan_editor/templates/elastic_search_river.json.j2
@@ -1,0 +1,14 @@
+{
+    "type" : "jdbc",
+    "jdbc" :
+        "driver" : "com.mysql.jdbc.Driver",
+        "url" : "jdbc:mysql://{{ vascan_editor_db_host }}:3306/{{ vascan_editor_db_name }}?useUnicode=true&characterEncoding=utf8&characterSetResults=utf8",
+        "user" : "{{ vascan_editor_db_user }}",
+        "password" : "{{ vascan_editor_db_password }}",
+        "sql" : "{{ item.value.sql }}",
+        "index" : "%s",
+        "type" : "{{ item.key }}",
+        "bulk_size" : 500,
+        "max_bulk_requests" : 10
+    }
+}

--- a/roles/app_vascan_editor/templates/installation_cfg.properties.j2
+++ b/roles/app_vascan_editor/templates/installation_cfg.properties.j2
@@ -1,6 +1,6 @@
 #Public URL of your portal. Must ends with a slash. Ex. http://data.canadensys.net/vascan/
 #If you are using the default Tomcat setup, the last part should be the name of the WAR file, normally vascan
-VascanRootURL= {{ vascan_editor_RootURL }}
+VascanRootURL= {{ vascan_editor_portal_url }}
 
 #Editor part
 database.username   = {{ vascan_editor_db_user }}

--- a/roles/app_vascan_editor/templates/log4j.properties.j2
+++ b/roles/app_vascan_editor/templates/log4j.properties.j2
@@ -1,0 +1,23 @@
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=1MB
+log4j.appender.file.MaxBackupIndex=1
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+log4j.appender.file.File={{ vascan_editor_dir_vascan_editor_log }}
+ 
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+ 
+# Root logger option
+log4j.rootLogger=INFO, file, stdout
+ 
+# Hibernate logging options (INFO only shows startup messages)
+log4j.logger.org.hibernate=INFO
+ 
+# Log JDBC bind parameter runtime arguments
+log4j.logger.org.hibernate.type=INFO
+#log4j.logger.org.hibernate.type=TRACE


### PR DESCRIPTION
Update to app_vascan_editor to allow to build the editor from source and completely configure it including its log file.